### PR TITLE
Fix montantDevise blank value

### DIFF
--- a/ValueObject/AbstractEcritureComptable.php
+++ b/ValueObject/AbstractEcritureComptable.php
@@ -492,7 +492,7 @@ abstract class AbstractEcritureComptable implements EcritureComptableInterface
             throw new \LogicException('setMontantdevise : "'.$montantDevise.'" is not a numeric value');
         }
 
-        $this->montantdevise = floatval($montantDevise);
+        $this->montantdevise = $montantDevise !== null ? floatval($montantDevise) : null;
 
         return $this;
     }


### PR DESCRIPTION
When the field montantDevis was filled with null, the resulting fec file
was filled with 0.00

If this field is filled with null, it now result in a blank value in the
fec file